### PR TITLE
Fix error_type/1 atom-to-string for ignore list matching

### DIFF
--- a/lib/airbrake_ex/notifier.ex
+++ b/lib/airbrake_ex/notifier.ex
@@ -122,7 +122,7 @@ defmodule AirbrakeEx.Notifier do
   end
 
   defp error_type(%{type: type}) when is_binary(type), do: type
-  defp error_type(%{type: type}) when is_atom(type), do: to_string(type)
+  defp error_type(%{type: type}) when is_atom(type), do: to_string_type(type)
   defp error_type(%{__struct__: type}) when is_atom(type), do: to_string_type(type)
   defp error_type(_), do: nil
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule AirbrakeEx.MixProject do
   def project do
     [
       app: :airbrake_ex,
-      version: "0.2.9",
+      version: "0.2.10",
       elixir: "~> 1.14",
       description: "Airbrake notifier for Elixir",
       package: package(),

--- a/test/airbrake_ex/notifier_test.exs
+++ b/test/airbrake_ex/notifier_test.exs
@@ -180,6 +180,12 @@ defmodule AirbrakeEx.NotifierTest do
     AirbrakeEx.Notifier.notify(error_to_ignore)
   end
 
+  test "does not notify if atom-typed map error is in ignore list", %{bypass: _bypass} do
+    Application.put_env(:airbrake_ex, :ignore, [SpecificError])
+
+    AirbrakeEx.Notifier.notify(%{type: SpecificError})
+  end
+
   test "notifies if error not in ignore list", %{bypass: bypass} do
     Application.put_env(:airbrake_ex, :ignore, [AnotherError])
 


### PR DESCRIPTION
Use to_string_type/1 instead of to_string/1 for plain map errors with an atom :type field, so the "Elixir." prefix is stripped and the result matches what ignore_type/1 produces. Without this, errors like %{type: Phoenix.Router.NoRouteError} were never filtered by the ignore list.

Adds a regression test covering this case.